### PR TITLE
Adapt the livepatch template to a new livepatch API

### DIFF
--- a/klp_test_livepatch.c
+++ b/klp_test_livepatch.c
@@ -67,6 +67,7 @@ static struct klp_patch patch = {
 
 static int livepatch_init(void)
 {
+#ifndef KLP_NOREG_API
 	int ret;
 
 	ret = klp_register_patch(&patch);
@@ -78,11 +79,16 @@ static int livepatch_init(void)
 		return ret;
 	}
 	return 0;
+#else
+	return klp_enable_patch(&patch);
+#endif
 }
 
 static void livepatch_exit(void)
 {
+#ifndef KLP_NOREG_API
 	WARN_ON(klp_unregister_patch(&patch));
+#endif
 }
 
 module_init(livepatch_init);


### PR DESCRIPTION
The atomic replace patch set among others removed the two-stage API.
There is no (un)registration step needed now. SLES backport defines
KLP_NOREG_API macro to easily distinguish whether the kernel provides
the old or the new API. Use it and change the module init function of
the template accordingly.

Signed-off-by: Miroslav Benes <mbenes@suse.cz>