### PR TITLE
Fixed required for running qa_test_klp in kernel v5.3

### DIFF
--- a/klp_compile_test_hrtimer.c
+++ b/klp_compile_test_hrtimer.c
@@ -1,0 +1,18 @@
+#include <linux/init.h>
+#include <linux/module.h>
+#include <linux/kernel.h>
+#include <linux/hrtimer.h>
+
+static int __init compile_test_mod_init(void)
+{
+	struct hrtimer_sleeper t;
+	hrtimer_init_sleeper(&t, current);
+	return 0;
+}
+
+static void __exit compile_test_mod_exit(void)
+{
+}
+
+module_init(compile_test_mod_init);
+module_exit(compile_test_mod_exit);

--- a/klp_tc_3.sh
+++ b/klp_tc_3.sh
@@ -24,7 +24,7 @@ set -e
 klp_tc_init "Test Case 3: Patch under pressure"
 
 klp_tc_milestone "Compiling kernel live patch"
-PATCH_KO="$(klp_create_patch_module tc_3 sys_getpid)"
+PATCH_KO="$(klp_create_patch_module tc_3 ${KLP_TEST_SYSCALL_FN_PREFIX}sys_getpid)"
 PATCH_MOD_NAME="$(basename "$PATCH_KO" .ko)"
 
 klp_tc_milestone "Compiling call_getpid"

--- a/klp_tc_5.sh
+++ b/klp_tc_5.sh
@@ -30,7 +30,7 @@ PATCH_DIR="/tmp/live-patch/tc_5"
 declare -a PATCH_KOS
 for N in $(seq 1 $N_PATCHES); do
     PATCH_SUBDIR="$PATCH_DIR/patch$N"
-    PATCH_KOS[$N]="$(klp_create_patch_module -o "$PATCH_SUBDIR" tc_5_$N sys_getpid)"
+    PATCH_KOS[$N]="$(klp_create_patch_module -o "$PATCH_SUBDIR" tc_5_$N ${KLP_TEST_SYSCALL_FN_PREFIX}sys_getpid)"
 done
 
 for N in $(seq 1 $N_PATCHES); do

--- a/klp_tc_6.sh
+++ b/klp_tc_6.sh
@@ -26,7 +26,7 @@ set -e
 klp_tc_init "Test Case 6: Patch while CPUs are busy"
 
 klp_tc_milestone "Compiling live patch"
-PATCH_KO="$(klp_create_patch_module tc_6 sys_getpid)"
+PATCH_KO="$(klp_create_patch_module tc_6 ${KLP_TEST_SYSCALL_FN_PREFIX}sys_getpid)"
 PATCH_MOD_NAME="$(basename "$PATCH_KO" .ko)"
 
 add_workload cpu

--- a/klp_tc_7.sh
+++ b/klp_tc_7.sh
@@ -25,7 +25,7 @@ set -e
 klp_tc_init "Test Case 7: Patch in low memory condition"
 
 klp_tc_milestone "Compiling live patch"
-PATCH_KO="$(klp_create_patch_module tc_7 sys_getpid)"
+PATCH_KO="$(klp_create_patch_module tc_7 ${KLP_TEST_SYSCALL_FN_PREFIX}sys_getpid)"
 PATCH_MOD_NAME="$(basename "$PATCH_KO" .ko)"
 
 add_workload mem

--- a/klp_tc_8.sh
+++ b/klp_tc_8.sh
@@ -30,7 +30,7 @@ PATCH_DIR="/tmp/live-patch/tc_8"
 declare -a PATCH_KOS
 for N in $(seq $N_PATCHES); do
     PATCH_SUBDIR="$PATCH_DIR/patch_replace-all_$N"
-    PATCH_KOS[$N]="$(klp_create_patch_module -r -o "$PATCH_SUBDIR" tc_8_$N sys_getpid)"
+    PATCH_KOS[$N]="$(klp_create_patch_module -r -o "$PATCH_SUBDIR" tc_8_$N ${KLP_TEST_SYSCALL_FN_PREFIX}sys_getpid)"
 done
 
 for N in $(seq 1 $N_PATCHES); do

--- a/klp_tc_functions.sh
+++ b/klp_tc_functions.sh
@@ -84,7 +84,7 @@ function klp_compile_module() {
     KERN_FLAVOR=$(uname -r | sed 's/^.*-//')
     KERN_ARCH=$(uname -m)
     make -C /usr/src/linux-$KERN_VERSION-obj/$KERN_ARCH/$KERN_FLAVOR \
-	M="$OUTPUT_DIR" O="$OUTPUT_DIR" 1>&2
+        M="$OUTPUT_DIR" modules 1>&2
     if [ $? -ne 0 ]; then
 	return 1
     fi

--- a/klp_tc_functions.sh
+++ b/klp_tc_functions.sh
@@ -287,3 +287,13 @@ function klp_tc_abort() {
     klp_tc_write "TEST CASE ABORT" "$*"
     exit 1
 }
+
+# detect environment settings
+KLP_ENV_CACHE_FILE=/tmp/live-patch/klp_env_cache
+if [ ! -f $KLP_ENV_CACHE_FILE ]; then
+    mkdir -p $(dirname $KLP_ENV_CACHE_FILE)
+
+    # environment detection check will go here
+    touch $KLP_ENV_CACHE_FILE
+fi
+. $KLP_ENV_CACHE_FILE

--- a/klp_test_livepatch.c
+++ b/klp_test_livepatch.c
@@ -25,15 +25,15 @@
 #define PATCH_GETPID @@PATCH_GETPID@@
 
 #if PATCH_GETPID
-asmlinkage long PATCHED_SYM(sys_getpid)(void)
+asmlinkage long PATCHED_SYM(@@SYSCALL_FN_PREFIX@@sys_getpid)(void)
 {
 	return task_tgid_vnr(current);
 }
 
 static struct klp_func vmlinux_funcs[] = {
 	{
-		.old_name = "sys_getpid",
-		.new_func = PATCHED_SYM(sys_getpid),
+		.old_name = "@@SYSCALL_FN_PREFIX@@sys_getpid",
+		.new_func = PATCHED_SYM(@@SYSCALL_FN_PREFIX@@sys_getpid),
 	},
 	{}
 };


### PR DESCRIPTION
Recent kernel API changes affected KLP tests. They are HR timer changes, decomissioning of jbprobes and syscall entry reimplementation on x86_64. Detect these changes at run time and reflect them in test behavior.
