### PR TITLE
Fix old registration API detection

### DIFF
--- a/klp_tc_functions.sh
+++ b/klp_tc_functions.sh
@@ -83,10 +83,7 @@ function klp_compile_module() {
     echo "obj-m += " $(basename "$SRC_FILE" .c)".o" \
 	> "$OUTPUT_DIR"/Makefile
 
-    KERN_VERSION=$(uname -r | sed 's/-[^-]*$//')
-    KERN_FLAVOR=$(uname -r | sed 's/^.*-//')
-    KERN_ARCH=$(uname -m)
-    make -C /usr/src/linux-$KERN_VERSION-obj/$KERN_ARCH/$KERN_FLAVOR \
+    make -C /lib/modules/$(uname -r)/build \
         M="$OUTPUT_DIR" modules 1>&2
     if [ $? -ne 0 ]; then
 	return 1

--- a/klp_tc_functions.sh
+++ b/klp_tc_functions.sh
@@ -67,6 +67,7 @@ s%@@PATCH_GETPID@@%$PATCH_GETPID%;
 s%@@SYSCALL_FN_PREFIX@@%$KLP_TEST_SYSCALL_FN_PREFIX%;
 s%@@PATCH_REPLACE_ALL@@%$PATCH_REPLACE_ALL%;
 s%@@PATCH_FUNCS@@%$PATCH_FUNCS%;
+s%@@USE_NOREG_API@@%$KLP_TEST_USE_NOREG_API%;
 EOF
     if [ ! -e "${SRC_FILE}" ] || \
        ! diff "${SRC_FILE}" "${SRC_FILE}.tmp" > /dev/null 2>&1; then
@@ -334,5 +335,10 @@ if [ ! -f $KLP_ENV_CACHE_FILE ]; then
     else
         echo >> $KLP_ENV_CACHE_FILE
     fi
+
+    # Decide whether to use simplified KLP API (kernel commit 958ef1e39d24)
+    echo -n 'export KLP_TEST_USE_NOREG_API=' >> $KLP_ENV_CACHE_FILE
+    # test for kernel 5.1.0 and newer
+    ( [ "$VERSION_CODE" -ge 327936 ] && echo "1" || echo "0" ) >> $KLP_ENV_CACHE_FILE
 fi
 . $KLP_ENV_CACHE_FILE

--- a/klp_tc_functions.sh
+++ b/klp_tc_functions.sh
@@ -315,8 +315,11 @@ if [ ! -f $KLP_ENV_CACHE_FILE ]; then
     echo -n 'export KLP_TEST_SYSCALL_FN_PREFIX=' >> $KLP_ENV_CACHE_FILE
 
     # generate LINUX_VERSION_CODE from `uname -r`
-    mapfile -t VERSION_PARTS < <(uname -r | cut -d- -f1 | tr . ' ')
-    VERSION_CODE=$(((VERSION_PARTS[0]<<16) + (VERSION_PARTS[1]<<8) + VERSION_PARTS[2]))
+    kver="$(uname -r | cut -d- -f1)"
+    part1="$(echo $kver | cut -d. -f1)"
+    part2="$(echo $kver | cut -d. -f2)"
+    part3="$(echo $kver | cut -d. -f3)"
+    VERSION_CODE=$(((part1 <<16) + (part2 <<8) + part3))
 
     if [ "$VERSION_CODE" -ge 266496 ] # test for kernel 4.17.0 and newer
     then

--- a/klp_tc_functions.sh
+++ b/klp_tc_functions.sh
@@ -27,6 +27,12 @@ function __klp_add_patched_func() {
     echo -n "\t},\n"
 }
 
+function klp_create_header() {
+    sed "s%@@USE_OLD_HRTIMER_API@@%$KLP_TEST_HRTIMER_OLD%" \
+	    "${SOURCE_DIR}/klp_test_support_mod.h" \
+	    > "${OUTPUT_DIR}/klp_test_support_mod.h"
+}
+
 # Create a livepatch source file from template
 # Parameters:
 #  - output file name
@@ -69,9 +75,7 @@ EOF
 	rm "${SRC_FILE}.tmp"
     fi
 
-    sed "s%@@USE_OLD_HRTIMER_API@@%$KLP_TEST_HRTIMER_OLD%" \
-	    "${SOURCE_DIR}/klp_test_support_mod.h" \
-	    > "${OUTPUT_DIR}/klp_test_support_mod.h"
+    klp_create_header
 }
 
 # Compile a kernel module
@@ -136,9 +140,8 @@ function klp_create_patch_module() {
 function klp_create_test_support_module() {
     local OUTPUT_DIR="$1"
 
-    sed "s%@@USE_OLD_HRTIMER_API@@%$KLP_TEST_HRTIMER_OLD%" \
-	    "${SOURCE_DIR}/klp_test_support_mod.h" \
-	    > "${OUTPUT_DIR}/klp_test_support_mod.h"
+    klp_create_header
+
     cp -u "${SOURCE_DIR}/klp_test_support_mod.c" "${OUTPUT_DIR}/"
     klp_compile_module "${OUTPUT_DIR}/klp_test_support_mod.c"
 }

--- a/klp_test_livepatch.c
+++ b/klp_test_livepatch.c
@@ -1,7 +1,7 @@
 /*
  * klp_test_livepatch - test livepatch template
  *
- *  Copyright (c) 2017-2018 SUSE
+ *  Copyright (c) 2017-2019 SUSE
  *   Authors: Libor Pechacek, Nicolai Stange
  */
 
@@ -23,6 +23,8 @@
 
 /* whether or not to identity-patch sys_getpid() */
 #define PATCH_GETPID @@PATCH_GETPID@@
+
+#define USE_NOREG_API @@USE_NOREG_API@@
 
 #if PATCH_GETPID
 asmlinkage long PATCHED_SYM(@@SYSCALL_FN_PREFIX@@sys_getpid)(void)
@@ -67,7 +69,7 @@ static struct klp_patch patch = {
 
 static int livepatch_init(void)
 {
-#ifndef KLP_NOREG_API
+#if !(defined(KLP_NOREG_API) || USE_NOREG_API)
 	int ret;
 
 	ret = klp_register_patch(&patch);
@@ -86,7 +88,7 @@ static int livepatch_init(void)
 
 static void livepatch_exit(void)
 {
-#ifndef KLP_NOREG_API
+#if !(defined(KLP_NOREG_API) || USE_NOREG_API)
 	WARN_ON(klp_unregister_patch(&patch));
 #endif
 }

--- a/klp_test_support_mod.h
+++ b/klp_test_support_mod.h
@@ -1,7 +1,7 @@
 /*
  * klp_test_support_mod - support module for KLP testing
  *
- *  Copyright (c) 2018 SUSE
+ *  Copyright (c) 2018-2019 SUSE
  *   Author: Nicolai Stange
  *
  * This program is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
Reliably detect whether functions from old API exists.
    
Depending on SLES specific KLP_NOREG_API does not work on Tumbleweed and mainline.
    
Fixes: f5e7bad Adapt the livepatch template to a new livepatch API