### PR TITLE
Revert "klp_tc_17: Avoid running the test on s390x"

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -15,7 +15,7 @@ klp_tc_13.sh|Patch traced function
 klp_tc_14.sh|Trace patched function
 klp_tc_15.sh|Patch graph-traced function
 klp_tc_16.sh|Graph-trace patched function
-klp_tc_17.sh|Check that patching a kprobed function fails|[ \"$(uname -m)\" != s390x ]
+klp_tc_17.sh|Check that patching a kprobed function fails
 "
 
 bats=$(which bats 2>/dev/null)


### PR DESCRIPTION
This reverts commit 43c79fbad385c61e8cfe742a85c8cb2c49277f98.

s390x has got HAVE_KPROBES_ON_FTRACE support since v5.6.

Signed-off-by: Miroslav Benes <mbenes@suse.cz>