### PR TITLE
klp_tc_functions.sh: Add aarch64 support to SYSCALL_FN_PREFIX

### DIFF
--- a/klp_tc_functions.sh
+++ b/klp_tc_functions.sh
@@ -354,6 +354,8 @@ if [ ! -f $KLP_ENV_CACHE_FILE ]; then
                 ;;
             s390x) echo "__s390x_" >> $KLP_ENV_CACHE_FILE
                 ;;
+            aarch64) echo "__arm64_" >> $KLP_ENV_CACHE_FILE
+                ;;
             *) echo >> $KLP_ENV_CACHE_FILE
                 ;;
         esac

--- a/klp_tc_functions.sh
+++ b/klp_tc_functions.sh
@@ -356,7 +356,10 @@ if [ ! -f $KLP_ENV_CACHE_FILE ]; then
                 ;;
             aarch64) echo "__arm64_" >> $KLP_ENV_CACHE_FILE
                 ;;
-            *) echo >> $KLP_ENV_CACHE_FILE
+            # CONFIG_ARCH_HAS_SYSCALL_WRAPPER is not set for ppc64le
+            ppc64le) echo >> $KLP_ENV_CACHE_FILE
+                ;;
+            *) klp_tc_abort "Arch $(uname -m) not supported"
                 ;;
         esac
     else


### PR DESCRIPTION
Without the prefix tc3 fails on aarch64.

Signed-off-by: Marcos Paulo de Souza <mpdesouza@suse.com>