### PR TITLE
Unload KLP test modules on error

### DIFF
--- a/klp_tc_functions.sh
+++ b/klp_tc_functions.sh
@@ -266,8 +266,29 @@ function klp_tc_write() {
     echo "$*"
 }
 
+function klp_tc_cleanup() {
+    klp_tc_milestone "Removing patches"
+
+    for P in ${MODULES_LOADED[@]}; do
+	if [ -d /sys/kernel/livepatch/"$P" ]; then
+	    klp_tc_milestone "Disabling and removing module $P"
+	    echo 0 > /sys/kernel/livepatch/"$P"/enabled
+	    if ! klp_wait_complete "$P" 61; then
+		klp_dump_blocking_processes
+		klp_tc_abort "module deactivation didn't finish in time"
+	    fi
+	else
+	    klp_tc_milestone "Removing module $P"
+	fi
+	if ! rmmod "$P"; then
+		dmesg | tail -30
+		klp_tc_abort "module removal failed"
+	fi
+    done
+}
+
 function klp_tc_init() {
-    trap "[ \$? -ne 0 ] && echo TEST FAILED while executing \'\$BASH_COMMAND\', EXITING; call_recovery_hooks" EXIT
+    trap "[ \$? -ne 0 ] && call_recovery_hooks; klp_tc_cleanup; echo TEST FAILED while executing \'\$BASH_COMMAND\'" EXIT
     # timestamp every line of output
     exec > >(awk '{ print strftime("[%T] ") $0 }')
     exec 2>&1
@@ -288,24 +309,7 @@ function register_mod_for_unload() {
 function klp_tc_exit() {
     trap - EXIT
 
-    klp_tc_milestone "Removing patches"
-
-    for P in ${MODULES_LOADED[@]}; do
-	if [ -d /sys/kernel/livepatch/"$P" ]; then
-	    klp_tc_milestone "Disabling and removing module $P"
-	    echo 0 > /sys/kernel/livepatch/"$P"/enabled
-	    if ! klp_wait_complete "$P" 61; then
-		klp_dump_blocking_processes
-		klp_tc_abort "module deactivation didn't finish in time"
-	    fi
-	else
-	    klp_tc_milestone "Removing module $P"
-	fi
-	if ! rmmod "$P"; then
-		dmesg | tail -30
-		klp_tc_abort "module removal failed"
-	fi
-    done
+    klp_tc_cleanup
 
     klp_tc_milestone "TEST PASSED"
 }

--- a/run.sh
+++ b/run.sh
@@ -15,7 +15,7 @@ klp_tc_13.sh|Patch traced function
 klp_tc_14.sh|Trace patched function
 klp_tc_15.sh|Patch graph-traced function
 klp_tc_16.sh|Graph-trace patched function
-klp_tc_17.sh|Check that patching a kprobed function fails|[ \"$(uname -m)\" != s390x ] || uname -r | grep -qEv '^([1-4]|5\.[1-5])\.'
+klp_tc_17.sh|Check that patching a kprobed function fails|[ \"$(uname -m)\" != aarch64 ] && ([ \"$(uname -m)\" != s390x ] || uname -r | grep -qEv '^([1-4]|5\.[1-5])\.')
 "
 
 bats=$(which bats 2>/dev/null)


### PR DESCRIPTION
This will enable running set of tests in a row even if some of them fail.