### PR TITLE
klp_tc_17: Don't run the test on aarch64

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -15,7 +15,7 @@ klp_tc_13.sh|Patch traced function
 klp_tc_14.sh|Trace patched function
 klp_tc_15.sh|Patch graph-traced function
 klp_tc_16.sh|Graph-trace patched function
-klp_tc_17.sh|Check that patching a kprobed function fails|[ \"$(uname -m)\" != s390x ] || uname -r | grep -qEv '^([1-4]|5\.[1-5])\.'
+klp_tc_17.sh|Check that patching a kprobed function fails|[ \"$(uname -m)\" != aarch64 ] && ([ \"$(uname -m)\" != s390x ] || uname -r | grep -qEv '^([1-4]|5\.[1-5])\.')
 "
 
 bats=$(which bats 2>/dev/null)


### PR DESCRIPTION
aarch64 don't have HAVE_KPROBES_ON_FTRACE. The test case thus fails,
but there is no issue with the implementation.