### PR TITLE
hiworkload: check missing dependencies

### DIFF
--- a/hiworkload/compile.sh
+++ b/hiworkload/compile.sh
@@ -3,6 +3,18 @@
 # Copyright (c) 2019 Petr Vorel <pvorel@suse.cz>
 set -e
 
+missing=
+for cmd in aclocal autoconf autoheader automake make; do
+	if ! command -v $cmd >/dev/null; then
+		echo "Missing '$cmd', install it!"
+		missing=1
+	fi
+done
+
+if [ "$missing" ]; then
+	exit 22
+fi
+
 aclocal
 autoconf
 autoheader

--- a/klp_tc_functions.sh
+++ b/klp_tc_functions.sh
@@ -288,7 +288,7 @@ function klp_tc_cleanup() {
 }
 
 function klp_tc_init() {
-    trap "[ \$? -ne 0 ] && call_recovery_hooks; klp_tc_cleanup; echo TEST FAILED while executing \'\$BASH_COMMAND\'" EXIT
+    trap "ret=\$?; [ \$ret -ne 0 ] && call_recovery_hooks; klp_tc_cleanup; result=FAILED; [ \$ret -eq 22 ] && result=SKIPPED; echo TEST \$result while executing \'\$BASH_COMMAND\'" EXIT
     # timestamp every line of output
     exec > >(awk '{ print strftime("[%T] ") $0 }')
     exec 2>&1
@@ -319,8 +319,12 @@ function klp_tc_milestone() {
 }
 
 function klp_tc_abort() {
-    klp_tc_write "TEST CASE ABORT" "$*"
-    exit 1
+    local ret=$?
+    local result="ABORT"
+
+    [ $ret -eq 22 ] && result="SKIPPED"
+    klp_tc_write "TEST CASE $result" "$*"
+    exit $ret
 }
 
 # detect environment settings


### PR DESCRIPTION
Basically print "TEST SKIPPED" instead of "TEST FAILED" when missing dependencies to compile `hiworkload`.