### PR TITLE
klp_tc_8.sh: Silence final rmmod

### DIFF
--- a/klp_tc_8.sh
+++ b/klp_tc_8.sh
@@ -62,7 +62,7 @@ done
 klp_tc_milestone "Testing final patch removal"
 PATCH_KO="${PATCH_KOS[$N_PATCHES]}"
 PATCH_MOD_NAME="$(basename "$PATCH_KO" .ko)"
-if rmmod "$PATCH_MOD_NAME"; then
+if rmmod "$PATCH_MOD_NAME" 2>/dev/null; then
     klp_tc_abort "It should not be possible to remove the kernel module ${PATCH_MOD_NAME}"
 fi
 


### PR DESCRIPTION
The final rmmod is supposed fail, therefore silence the final rmmod error:
```
[19:27:02] rmmod: ERROR: Module klp_tc_8_4_livepatch is in use
```

This error message is misleading, because does nothing in common with test failure:

* failing test
...
```
[19:27:02] *** Removing getpid patch 4
[19:27:02] rmmod: ERROR: Module klp_tc_8_4_livepatch is in use [19:27:02] *** Removing patches
[19:27:02] TEST FAILED while executing 'rmmod "$PATCH_MOD_NAME"'
```

* passed test (on different machine)
```
...
[06:20:57] *** Removing getpid patch 4
[06:20:57] *** Testing final patch removal
[06:20:57] rmmod: ERROR: Module klp_tc_8_5_livepatch is in use [06:20:57] *** Removing patches
[06:20:57] *** Disabling and removing module klp_tc_8_5_livepatch [06:20:59] *** TEST PASSED
```