### PR TITLE
klp_test_support_mod: add hrtimer_setup*() detection

### DIFF
--- a/klp_tc_functions.sh
+++ b/klp_tc_functions.sh
@@ -28,7 +28,8 @@ function __klp_add_patched_func() {
 }
 
 function klp_create_header() {
-    sed "s%@@USE_OLD_HRTIMER_API@@%$KLP_TEST_HRTIMER_OLD%" \
+    sed -e "s%@@USE_OLD_HRTIMER_API@@%$KLP_TEST_HRTIMER_OLD%" \
+	-e "s%@@USE_6_13_HRTIMER_API@@%$KLP_TEST_USE_6_13_HRTIMER_API%" \
 	    "${SOURCE_DIR}/klp_test_support_mod.h" \
 	    > "${OUTPUT_DIR}/klp_test_support_mod.h"
 }
@@ -378,5 +379,9 @@ if [ ! -f $KLP_ENV_CACHE_FILE ]; then
     # based on presence of an obsolete API function
     echo -n 'export KLP_TEST_USE_OLD_REG_API=' >> $KLP_ENV_CACHE_FILE
     ( grep -q 'T klp_register_patch$' /proc/kallsyms && echo "1" || echo "0" ) >> $KLP_ENV_CACHE_FILE
+
+    # Decide whether to use hrtimer_setup*() API (kernel commit c9bd83abfeb9)
+    echo -n 'export KLP_TEST_USE_6_13_HRTIMER_API=' >> $KLP_ENV_CACHE_FILE
+    ( grep -q 'T hrtimer_setup_sleeper_on_stack$' /proc/kallsyms && echo "1" || echo "0" ) >> $KLP_ENV_CACHE_FILE
 fi
 . $KLP_ENV_CACHE_FILE

--- a/klp_test_support_mod.h
+++ b/klp_test_support_mod.h
@@ -21,6 +21,7 @@
 #include <asm/uaccess.h>
 
 #define USE_OLD_HRTIMER_API @@USE_OLD_HRTIMER_API@@
+#define USE_6_13_HRTIMER_API @@USE_6_13_HRTIMER_API@@
 
 #if defined(PATCH_ID)
 #define __PATCHED_SYM(id, sym) klp_ ## id ## _ ## sym
@@ -130,6 +131,9 @@ int PATCHED_SYM(do_sleep)(unsigned long secs, int task_state)
 	hrtimer_init_on_stack(&t.timer, CLOCK_MONOTONIC, HRTIMER_MODE_REL);
 	hrtimer_set_expires_range_ns(&t.timer, ktime_set(secs, 0), 0);
 	hrtimer_init_sleeper(&t, current);
+#elif USE_6_13_HRTIMER_API
+	hrtimer_setup_sleeper_on_stack(&t, CLOCK_MONOTONIC, HRTIMER_MODE_REL);
+	hrtimer_set_expires_range_ns(&t.timer, ktime_set(secs, 0), 0);
 #else
 	hrtimer_init_sleeper_on_stack(&t, CLOCK_MONOTONIC, HRTIMER_MODE_REL);
 	hrtimer_set_expires_range_ns(&t.timer, ktime_set(secs, 0), 0);


### PR DESCRIPTION
The hrtimer_init*() API is replaced by hrtimer_setup*() variants in linux kernel.  Hence use hrtimer_setup*() in klp module, when it is available.

Reference linux commit:
c9bd83abfeb9 ("hrtimers: Introduce hrtimer_setup_sleeper_on_stack()")


v2 (Thanks Miroslav):
* Use version numbers for hrtimer apis. 
   i.e USE_6_13_HRTIMER_API instead of USE_NEW_HRTIMER_SETUP_API
   Couldnt estimate the exact kernel version of hrtimer_init_sleeper() with two arguments.
   Hence, did not rename USE_OLD_HRTIMER_API.
* Provide separate #ifdef in klp_test_support_mod.h.