### PR TITLE
klp_test_livepatch: Add missing MODULE_DESCRIPTION()

### DIFF
--- a/klp_test_livepatch.c
+++ b/klp_test_livepatch.c
@@ -96,4 +96,5 @@ static void livepatch_exit(void)
 module_init(livepatch_init);
 module_exit(livepatch_exit);
 MODULE_LICENSE("GPL");
+MODULE_DESCRIPTION("klp tests");
 MODULE_INFO(livepatch, "Y");

--- a/klp_test_support_mod.c
+++ b/klp_test_support_mod.c
@@ -430,3 +430,4 @@ static void test_support_mod_exit(void)
 module_init(test_support_mod_init);
 module_exit(test_support_mod_exit);
 MODULE_LICENSE("GPL");
+MODULE_DESCRIPTION("klp tests");


### PR DESCRIPTION
When building klp tc modules, following warning is emitted. WARNING: modpost: missing MODULE_DESCRIPTION() in
klp_tc_3_livepatch.o

Fix the warning by adding MODULE_DESCRIPTION().