### PR TITLE
README: Mark TC6 as implemented on kselftests

### DIFF
--- a/README
+++ b/README
@@ -11,7 +11,7 @@ TC3 Patch under pressure (already tested on kselftests)
 TC5 Test kernel live patching in quick succession
     * Apply one patch after another in quick succession.
 
-TC6 Patch while CPUs are busy
+TC6 Patch while CPUs are busy (already tested in kselftests)
     * Make CPUs busy in user space and patch.
 
 TC7 Test kernel live patching in low-memory condition


### PR DESCRIPTION
The kernel commit 6a71770442b5 ("selftests: livepatch: Test livepatching a heavily called syscall") already tests if we can livepatch in a busy CPUs environment, similar of what TC6 tests, but on the TC6 case the function that will be patched is not even called, which is weaker as a test compared to TC3 (the test that was ported on 6a71770442b5).