### PR TITLE
chimem: Reset loop flag before forking

### DIFF
--- a/hiworkload/src/chimem.c
+++ b/hiworkload/src/chimem.c
@@ -125,7 +125,6 @@ worker (size_t length)
         exit(5);
     }
     /* todo SET proc name */
-    wloop_reset();
     wloop_run();
     fprintf(stdout, "%lu finished.\n", getpid());
 }
@@ -137,6 +136,7 @@ leader (int num_worker, size_t length_per_worker)
     int ret;
     int i;
 
+    wloop_reset();
     ret = sig_install_handlers();
     if (ret < 0) {
         fprintf(stderr, "%lu failed to install sig handlers\n",
@@ -158,7 +158,6 @@ leader (int num_worker, size_t length_per_worker)
     }
 
     /* waiting */
-    wloop_reset();
     wloop_run();
 
     /* get childs */


### PR DESCRIPTION
The memory workload has a race condition where the terminate signal from parent script may be delivered before the workload is fully initialized. If the tool resets the loop flag after the signal was delivered, it'll keep running indefinitely. Reset the flag before installing the signal handler to ensure that the main process will react to the signal correctly.