### PR TITLE
Update README - set TC13 as tested on kselftests

### DIFF
--- a/README
+++ b/README
@@ -34,7 +34,7 @@ TC12 Patch caller of kretprobed callee
     * Check that the reliable stacktrace implementation is able to
       discover callers of functions with a kretprobe on them.
 
-TC13 Patch traced function
+TC13 Patch traced function (already tested in kselftests)
     * Patch a function which is being traced and check that the live
       patch really is in effect.
 


### PR DESCRIPTION
The patch is currently on livepatch/for-next repository: 

https://git.kernel.org/pub/scm/linux/kernel/git/livepatching/livepatching.git/commit/?h=for-next&id=920e5001f4beb38685d5b8cac061cb1d2760eeab